### PR TITLE
Correct functions.php path for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
             "OpenTelemetry\\SDK\\": "."
         },
         "files": [
-            "src/SDK/Common/Util/functions.php"
+            "Common/Util/functions.php"
         ]
     },
     "suggest": {


### PR DESCRIPTION
Composer was unable to complete an update on dev-main because functions.php could not be found.

Tracked down to the sdk package